### PR TITLE
Update scale-down policy from `1` instance at the time to `5%` of ASG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 IMAGE            ?= 971383676178.dkr.ecr.us-east-1.amazonaws.com/kube-aws-autoscaler
 VERSION          ?= $(shell git describe --tags --always --dirty)
-TAG              ?= 0.9.2
+TAG              ?= 0.9.2.1
 GITHEAD          = $(shell git rev-parse --short HEAD)
 GITURL           = $(shell git config --get remote.origin.url)
 GITSTATU         = $(shell git status --porcelain || echo "no changes")

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 IMAGE            ?= 971383676178.dkr.ecr.us-east-1.amazonaws.com/kube-aws-autoscaler
 VERSION          ?= $(shell git describe --tags --always --dirty)
-TAG              ?= 0.9.2.1
+TAG              ?= 0.9.3
 GITHEAD          = $(shell git rev-parse --short HEAD)
 GITURL           = $(shell git config --get remote.origin.url)
 GITSTATU         = $(shell git status --porcelain || echo "no changes")

--- a/kube_aws_autoscaler/main.py
+++ b/kube_aws_autoscaler/main.py
@@ -189,8 +189,8 @@ def slow_down_downscale(asg_sizes: dict, nodes_by_asg_zone: dict):
 
     for asg_name, desired_size in sorted(asg_sizes.items()):
         amount_of_downscale = node_counts_by_asg[asg_name] - desired_size
-        if amount_of_downscale >= 2:
-            new_desired_size = node_counts_by_asg[asg_name] - 1
+        if amount_of_downscale >= 2:            
+            new_desired_size = max(desired_size *.05, node_counts_by_asg[asg_name] * 0.05)
             logger.info('Slowing down downscale: changing desired size of ASG {} from {} to {}'.format(asg_name, desired_size, new_desired_size))
             asg_sizes[asg_name] = new_desired_size
 

--- a/kube_aws_autoscaler/main.py
+++ b/kube_aws_autoscaler/main.py
@@ -189,8 +189,8 @@ def slow_down_downscale(asg_sizes: dict, nodes_by_asg_zone: dict):
 
     for asg_name, desired_size in sorted(asg_sizes.items()):
         amount_of_downscale = node_counts_by_asg[asg_name] - desired_size
-        if amount_of_downscale >= 2:            
-            new_desired_size = max(desired_size *.05, node_counts_by_asg[asg_name] * 0.05)
+        if amount_of_downscale >= 2:
+            new_desired_size = max(desired_size * 0.05, node_counts_by_asg[asg_name] * 0.05)
             logger.info('Slowing down downscale: changing desired size of ASG {} from {} to {}'.format(asg_name, desired_size, new_desired_size))
             asg_sizes[asg_name] = new_desired_size
 

--- a/kube_aws_autoscaler/main.py
+++ b/kube_aws_autoscaler/main.py
@@ -190,7 +190,7 @@ def slow_down_downscale(asg_sizes: dict, nodes_by_asg_zone: dict):
     for asg_name, desired_size in sorted(asg_sizes.items()):
         amount_of_downscale = node_counts_by_asg[asg_name] - desired_size
         if amount_of_downscale >= 2:
-            new_desired_size = max(desired_size * 0.05, node_counts_by_asg[asg_name] * 0.05)
+            new_desired_size = max(desired_size * 0.95, node_counts_by_asg[asg_name] * 0.95)
             logger.info('Slowing down downscale: changing desired size of ASG {} from {} to {}'.format(asg_name, desired_size, new_desired_size))
             asg_sizes[asg_name] = new_desired_size
 

--- a/kube_aws_autoscaler/main.py
+++ b/kube_aws_autoscaler/main.py
@@ -4,6 +4,7 @@ import argparse
 import collections
 import itertools
 import logging
+import math
 import os
 import re
 import time
@@ -190,7 +191,7 @@ def slow_down_downscale(asg_sizes: dict, nodes_by_asg_zone: dict):
     for asg_name, desired_size in sorted(asg_sizes.items()):
         amount_of_downscale = node_counts_by_asg[asg_name] - desired_size
         if amount_of_downscale >= 2:
-            new_desired_size = max(desired_size * 0.95, node_counts_by_asg[asg_name] * 0.95)
+            new_desired_size = max(desired_size, int(math.floor(0.95 * node_counts_by_asg[asg_name])))
             logger.info('Slowing down downscale: changing desired size of ASG {} from {} to {}'.format(asg_name, desired_size, new_desired_size))
             asg_sizes[asg_name] = new_desired_size
 


### PR DESCRIPTION
### Overview
We are using `kube-aws-autoscaler` to control cluster size (scale-up/scale-down).
We have discovered that `scale-down` event takes **too long** due to conservative nature of `kube-aws-autoscaler` scaling down policy - `1` instance at the time.

```
2017-06-23 22:02:31,436 INFO: tf-asg-20170111035404272042231gya/us-east-1b:                       CPU     MEMORY       PODS
2017-06-23 22:02:31,436 INFO: tf-asg-20170111035404272042231gya/us-east-1b: requested:          204.7   133640Mi        963
2017-06-23 22:02:31,436 INFO: tf-asg-20170111035404272042231gya/us-east-1b: with buffer:        256.0   147204Mi       1069
2017-06-23 22:02:31,436 INFO: tf-asg-20170111035404272042231gya/us-east-1b: weakest node:        40.0   161186Mi        110
2017-06-23 22:02:31,436 INFO: tf-asg-20170111035404272042231gya/us-east-1b: overprovision:      195.3  1478221Mi        137
2017-06-23 22:02:31,436 INFO: tf-asg-20170111035404272042231gya/us-east-1b: => 11 nodes required (current: 101)
2017-06-23 22:02:31,437 INFO: tf-asg-20170111035404272042231gya/us-east-1c:                       CPU     MEMORY       PODS
2017-06-23 22:02:31,437 INFO: tf-asg-20170111035404272042231gya/us-east-1c: requested:          176.5    44782Mi        620
2017-06-23 22:02:31,437 INFO: tf-asg-20170111035404272042231gya/us-east-1c: with buffer:        220.8    49460Mi        692
2017-06-23 22:02:31,437 INFO: tf-asg-20170111035404272042231gya/us-east-1c: weakest node:        40.0   161186Mi        110
2017-06-23 22:02:31,437 INFO: tf-asg-20170111035404272042231gya/us-east-1c: overprovision:      103.5  1083520Mi        150
2017-06-23 22:02:31,437 INFO: tf-asg-20170111035404272042231gya/us-east-1c: => 8 nodes required (current: 51)
2017-06-23 22:02:31,437 INFO: tf-asg-20170111035404272042231gya/us-east-1d:                       CPU     MEMORY       PODS
2017-06-23 22:02:31,437 INFO: tf-asg-20170111035404272042231gya/us-east-1d: requested:          200.1    70870Mi        968
2017-06-23 22:02:31,437 INFO: tf-asg-20170111035404272042231gya/us-east-1d: with buffer:        250.3    78157Mi       1075
2017-06-23 22:02:31,437 INFO: tf-asg-20170111035404272042231gya/us-east-1d: weakest node:        40.0   161186Mi        110
2017-06-23 22:02:31,438 INFO: tf-asg-20170111035404272042231gya/us-east-1d: overprovision:      199.9  1540990Mi        132
2017-06-23 22:02:31,438 INFO: tf-asg-20170111035404272042231gya/us-east-1d: => 11 nodes required (current: 102)
2017-06-23 22:02:31,438 INFO: Slowing down downscale: changing desired size of ASG tf-asg-20170111035404272042231gya from 30 to 253
```

`INFO: Slowing down downscale: changing desired size of ASG tf-asg-20170111035404272042231gya from 30 to 253`

Based on POD CPU/Memory resource utilization new cluster size should be `30` nodes, however, `kube-aws-autoscaler` decrements from `254`->`253`. 

It takes on average `5 minutes` + for ASG to terminate a given instance, with most time spent on `ELB Connection Draining`:
![image](https://user-images.githubusercontent.com/324803/27556700-7ca65e70-5a6b-11e7-961a-9b3d0c9c3fdc.png)

### Changes
Update scale down process from `1 instance` to `5%` of ASG. 
![image](https://user-images.githubusercontent.com/324803/27556785-e27b40bc-5a6b-11e7-8caf-da494668f2a9.png)

### Impact 
Should be no impact.
