### PR TITLE
Log the size of ASG when slowing down downscaling

### DIFF
--- a/kube_aws_autoscaler/main.py
+++ b/kube_aws_autoscaler/main.py
@@ -192,7 +192,7 @@ def slow_down_downscale(asg_sizes: dict, nodes_by_asg_zone: dict):
         amount_of_downscale = node_counts_by_asg[asg_name] - desired_size
         if amount_of_downscale >= 2:
             new_desired_size = max(desired_size, int(math.floor(0.95 * node_counts_by_asg[asg_name])))
-            logger.info('Slowing down downscale: changing desired size of ASG {} from {} to {}'.format(asg_name, desired_size, new_desired_size))
+            logger.info('Slowing down downscale: changing desired size of ASG {} (current size is {}) from {} to {}'.format(asg_name, node_counts_by_asg[asg_name], desired_size, new_desired_size))
             asg_sizes[asg_name] = new_desired_size
 
     return asg_sizes


### PR DESCRIPTION
Log the current ASG size to better understand occasionally observed weird behavior when autoscaler tries to downscale ASG and upscales it instead.